### PR TITLE
refactor: Removed redundant else block from when expression

### DIFF
--- a/a2a/src/commonJvmAndroidMain/kotlin/com/google/adk/kt/a2a/converters/A2aConverters.kt
+++ b/a2a/src/commonJvmAndroidMain/kotlin/com/google/adk/kt/a2a/converters/A2aConverters.kt
@@ -280,7 +280,6 @@ private fun TaskUpdateEvent.toAdkEvent(context: InvocationContext): Event? {
         metadataParser,
       )
     }
-    else -> null
   }
 }
 


### PR DESCRIPTION
## Summary

This PR removes a redundant `else` branch from the `TaskUpdateEvent.toAdkEvent` private conversion helper.

The `when` expression is already covered by the known task update event cases, so the extra fallback is unnecessary.

No behavior change is intended.

## Validation

- `./gradlew.bat :google-adk-kotlin-a2a:build`