### PR TITLE
fix: correct `resolveScopedArtifactDir` windows path validation

### DIFF
--- a/core/src/commonJvmAndroidMain/kotlin/com/google/adk/kt/artifacts/FileArtifactService.kt
+++ b/core/src/commonJvmAndroidMain/kotlin/com/google/adk/kt/artifacts/FileArtifactService.kt
@@ -276,9 +276,14 @@ class FileArtifactService(private val baseDir: String) : ArtifactService {
     // Normalize Windows separators so the same name resolves identically on every platform.
     val stripped = stripUserNamespace(filename).trim().replace('\\', '/')
     val relative = Paths.get(stripped).normalize()
-    require(!relative.isAbsolute && !relative.startsWith(Paths.get(".."))) {
+    require(
+      !stripped.startsWith("/") &&
+          !relative.isAbsolute &&
+          !relative.startsWith(Paths.get("..")) &&
+          !Regex("^[A-Za-z]:").containsMatchIn(stripped)
+    ) {
       "Artifact filename '$filename' must be relative to the storage scope and must not traverse " +
-        "outside it."
+          "outside it."
     }
     val relativeString = relative.toString()
     return if (relativeString.isEmpty()) {

--- a/core/src/commonJvmAndroidTest/kotlin/com/google/adk/kt/artifacts/FileArtifactServiceTest.kt
+++ b/core/src/commonJvmAndroidTest/kotlin/com/google/adk/kt/artifacts/FileArtifactServiceTest.kt
@@ -171,9 +171,30 @@ class FileArtifactServiceTest {
   }
 
   @Test
-  fun saveArtifact_absoluteFilename_throws() = runTest {
+  fun saveArtifact_posixAbsoluteFilename_throws() = runTest {
     assertFailsWith<IllegalArgumentException> {
       service.saveArtifact(SESSION_KEY, "/etc/passwd", part("x"))
+    }
+  }
+
+  @Test
+  fun saveArtifact_windowsRootedAbsoluteFilename_throws() = runTest {
+    assertFailsWith<IllegalArgumentException> {
+      service.saveArtifact(SESSION_KEY, """C:\\etc\\passwd""", part("x"))
+    }
+  }
+
+  @Test
+  fun saveArtifact_windowsRootRelativeFilename_throws() = runTest {
+    assertFailsWith<IllegalArgumentException> {
+      service.saveArtifact(SESSION_KEY, """\etc\passwd""", part("x"))
+    }
+  }
+
+  @Test
+  fun saveArtifact_windowsDriveRelativeFilename_throws() = runTest {
+    assertFailsWith<IllegalArgumentException> {
+      service.saveArtifact(SESSION_KEY, """C:etc\passwd""", part("x"))
     }
   }
 


### PR DESCRIPTION
## Summary
This PR fixes the path issue in `resolveScopedArtifactDir()` where the java considering path start with '/' as relative path in windows system which it is an absolute path in Linux based system.

## Validation
./gradlew check