### PR TITLE
refactor: Avoid unnecessary JsonObject creation in `STATE.REMOVED` branch

### DIFF
--- a/core/src/commonMain/kotlin/com/google/adk/kt/serialization/Serializers.kt
+++ b/core/src/commonMain/kotlin/com/google/adk/kt/serialization/Serializers.kt
@@ -44,7 +44,9 @@ import kotlinx.serialization.modules.SerializersModule
  * decodes a single-key object with this marker back into [State.REMOVED].
  */
 private const val REMOVED_MARKER = "__ADK_SENTINEL_REMOVED__"
-
+private val REMOVED_JSON = lazy {
+  JsonObject(mapOf(REMOVED_MARKER to JsonPrimitive(true)))
+}
 /**
  * `kotlinx.serialization` serializer for free-form `Any` values that appear in the [Event] graph
  * (state deltas, `FunctionCall.args`, `FunctionResponse.response`, `customMetadata`, tool
@@ -81,7 +83,7 @@ internal object AnySerializer : KSerializer<Any> {
 fun anyToJsonElement(value: Any?): JsonElement =
   when (value) {
     null -> JsonNull
-    State.REMOVED -> JsonObject(mapOf(REMOVED_MARKER to JsonPrimitive(true)))
+    State.REMOVED -> REMOVED_JSON.value
     is JsonElement -> value
     is String -> JsonPrimitive(value)
     is Boolean -> JsonPrimitive(value)


### PR DESCRIPTION
# Summary #
- This PR created a lazy `REMOVED_JSON` variable as Json element for `STATE.REMOVED` value.
- Previously a `JsonObject` is being created on request which is constant with respect to `STATE.REMOVED` so lazy `REMOVED_JSON` created so it will be created once on demand.
# Validation #
- ```./gradlew clean build```