### PR TITLE
feat: Improved the InMemorySessionService performance

### DIFF
--- a/core/src/commonMain/kotlin/com/google/adk/kt/sessions/InMemorySessionService.kt
+++ b/core/src/commonMain/kotlin/com/google/adk/kt/sessions/InMemorySessionService.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.sync.withLock
 class InMemorySessionService : SessionService {
   private val mutex = Mutex()
   private val sessions: MutableMap<SessionKey, Session> = mutableMapOf()
+  private val sessionIndex: MutableMap<UserKey, MutableSet<SessionKey>> = mutableMapOf()
   private val userState: MutableMap<UserKey, MutableMap<String, Any>> = mutableMapOf()
   private val appState: MutableMap<String, MutableMap<String, Any>> = mutableMapOf()
 
@@ -53,8 +54,9 @@ class InMemorySessionService : SessionService {
           events = mutableListOf(),
           lastUpdateTime = Clock.System.now(),
         )
-
-      sessions[SessionKey(key.appName, key.userId, resolvedSessionId)] = newSession
+      val sessionKey = SessionKey(key.appName, key.userId, resolvedSessionId)
+      sessions[sessionKey] = newSession
+      sessionIndex.getOrPut(UserKey(key.appName, key.userId)) { mutableSetOf() }.add(sessionKey)
 
       // Create a mutable copy and merge global state into it before returning.
       mergeWithGlobalState(key.appName, key.userId, copySession(newSession))
@@ -73,25 +75,30 @@ class InMemorySessionService : SessionService {
       mergeWithGlobalState(key.appName, key.userId, sessionCopy)
     }
 
-  override suspend fun listSessions(appName: String, userId: String): ListSessionsResponse =
-    mutex.withLock {
-      val sessionCopies =
-        sessions.entries
-          .asSequence()
-          .filter { it.key.appName == appName && it.key.userId == userId }
-          .map { (_, session) ->
-            // Create copies with empty events and state for the response
-            val copy = copySession(session)
-            copy.events.clear()
+  override suspend fun listSessions(appName: String, userId: String): ListSessionsResponse {
+    val indexKey = UserKey(appName, userId)
+    return mutex.withLock {
+      val sessionCopies = sessionIndex[indexKey]
+        .orEmpty()
+        .mapNotNull { sessionKey ->
+          sessions[sessionKey]?.let { originalSession ->
+            val copy = copySessionWithoutEvent(originalSession)
             mergeWithGlobalState(appName, userId, copy)
           }
-          .toList()
-
+        }
       ListSessionsResponse(sessions = sessionCopies)
     }
+  }
 
   override suspend fun deleteSession(key: SessionKey) {
-    mutex.withLock { sessions.remove(key) }
+    mutex.withLock {
+      sessions.remove(key)
+      val indexKey = UserKey(key.appName, key.userId)
+      sessionIndex[indexKey]?.let { sessionSet ->
+        sessionSet.remove(key)
+        if (sessionSet.isEmpty()) sessionIndex.remove(indexKey)
+      }
+    }
   }
 
   override suspend fun listEvents(key: SessionKey): ListEventsResponse = mutex.withLock {
@@ -154,6 +161,15 @@ class InMemorySessionService : SessionService {
       // Keep the copy's event list concurrent too (toMutableList() would return a plain ArrayList),
       // so a caller iterating it while the runner appends does not hit a CME.
       events = concurrentMutableListOf<Event>().apply { addAll(events) },
+      lastUpdateTime = original.lastUpdateTime,
+    )
+  }
+
+  private fun copySessionWithoutEvent(original: Session): Session {
+    return Session(
+      key = original.key,
+      state = State(initialState = original.state),
+      events = concurrentMutableListOf<Event>(),
       lastUpdateTime = original.lastUpdateTime,
     )
   }


### PR DESCRIPTION
## Description ##
- Created an index for session which link the `appName` and `userId` to `SessionKey`. This will help to improve lookup speed in the `listSessions` method.
- Earlier `copySession` copy the whole session along with its events but in certain places like `listSession` method after copy events are cleared from list. If we know we don't need events then why bothering copying them, thats why a separate private method `copySessionWithoutEvent` created.
- The value of the index is a type of `MutableSet` because it avoids duplication and also help to delete `sessionKey` in better way than `ArrayList`.

## Tests ##
- `./gradlew test`